### PR TITLE
Add dependabot to track packages updates on NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    # Check for npm updates at 16 UTC == 9am PT
+    time: "16:00"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
 # Change log
 
 List of changes for every update.
+
+- 0.0.2
+    - UI components and helper methods and signal scan related libraries (Wi-Fi and Cell scans) were moved to a new repo: [fbc-mobile-app-core](https://github.com/facebookincubator/fbc-mobile-app-core/)
+    - New NPM components are published:
+        - [@fbcmobile/signalscan](https://www.npmjs.com/package/@fbcmobile/signalscan)
+        - [@fbcmobile/ui](https://www.npmjs.com/package/@fbcmobile/ui)
+    - New dependabot config added to create a PR for importing these packages once changes are discovered.


### PR DESCRIPTION
Summary:
- Followed steps to add dependabot here: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates
- Set version to `0.0.2`
- Added a changelog to explain latest changes

Reviewed By: apbuteau

Differential Revision: D24165001

